### PR TITLE
Make reporter configurable, off by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,10 @@ Automatically insert legacy fallbacks for modern properties - via [laggard][lagg
 }
 ```
 
+###### Reporter
+
+If you set this option to `true`, it will enable [postcss-reporter](https://github.com/postcss/postcss-reporter), which shows helpful error and warning messages from other plugin in your console.
+
 --
 
 **Read the full docs at http://simplaio.github.io/rucksack**
@@ -242,6 +246,7 @@ Core features (default to `true`):
 Addons (default to `false`):
 - `fallbacks`
 - `autoprefixer`
+- `reporter`
 
 ```js
 // Set in build tool, etc.

--- a/index.js
+++ b/index.js
@@ -28,7 +28,8 @@ reporter = require('postcss-reporter');
 // Default options
 defaults = {
   autoprefixer: false,
-  fallbacks: false
+  fallbacks: false,
+  reporter: false
 };
 
 // Build PostCSS plugin
@@ -53,7 +54,7 @@ rucksack = $postcss.plugin('rucksack', function(options) {
     }
   });
 
-  plugins.push(reporter);
+  options.reporter && plugins.push(reporter);
 
   // Build PostCSS bundle
   plugins.forEach(function(plugin){


### PR DESCRIPTION
Having the reporter, which logs lots os messages to the console, on by default and impossible to disable, is a pretty rough feature add for a lot of people. This PR makes it optional.

Closes #44 
